### PR TITLE
fix compile error with of0.11.0

### DIFF
--- a/src/ofxBasicSoundPlayer.h
+++ b/src/ofxBasicSoundPlayer.h
@@ -7,11 +7,12 @@
 
 #pragma once
 
-#include "ofBaseSoundPlayer.h"
+#include "ofSoundBaseTypes.h"
 #include "ofBaseTypes.h"
 #include "ofConstants.h"
 #include "ofSoundBuffer.h"
 #include "ofThread.h"
+#include "ofLog.h"
 
 #include "ofSoundStream.h"
 #include "ofEvents.h"

--- a/src/ofxSoundFile.h
+++ b/src/ofxSoundFile.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "ofConstants.h"
+#include "ofMathConstants.h"
 #include "ofSoundBuffer.h"
 
 #if defined (TARGET_OSX) || defined (TARGET_WIN32) || defined (TARGET_OS_IPHONE)


### PR DESCRIPTION
include some headers.

My emvironment is Windows 10 + VisualStudio 2019(with build tools) + of0.11.0.
This list is probrems I fixed.
1. 'MIN': identifier not found (ofxbasicsoundplayer\src\ofxsoundfile.cpp 154)
2. Cannot open include file: 'ofBaseSoundPlayer.h': No such file or directory (ofxbasicsoundplayer\src\ofxbasicsoundplayer.h 10)

Could you pull this?